### PR TITLE
Add engine options for setting crit/overhit damage multipliers

### DIFF
--- a/docs/attribute-reference.html
+++ b/docs/attribute-reference.html
@@ -1555,6 +1555,10 @@ body {
 
 <p><strong>miss_damage_percent</strong> | <code>int, int : Minimum, Maximum</code> | The percentage of damage dealt when a miss occurs.</p>
 
+<p><strong>crit_damage_percent</strong> | <code>int, int : Minimum, Maximum</code> | The percentage of damage dealt when a critical hit occurs.</p>
+
+<p><strong>overhit_damage_percent</strong> | <code>int, int : Minimum, Maximum</code> | The percentage of damage dealt when an overhit occurs.</p>
+
 <hr />
 
 <h4>Settings: Elements</h4>

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -167,6 +167,10 @@ int MIN_BLOCK;
 int MIN_AVOIDANCE;
 int MIN_MISS_DAMAGE;
 int MAX_MISS_DAMAGE;
+int MIN_CRIT_DAMAGE;
+int MAX_CRIT_DAMAGE;
+int MIN_OVERHIT_DAMAGE;
+int MAX_OVERHIT_DAMAGE;
 
 // Elemental types
 std::vector<Element> ELEMENTS;
@@ -316,6 +320,10 @@ void loadMiscSettings() {
 	MIN_AVOIDANCE = 0;
 	MIN_MISS_DAMAGE = 0;
 	MAX_MISS_DAMAGE = 0;
+	MIN_CRIT_DAMAGE = 200;
+	MAX_CRIT_DAMAGE = 200;
+	MIN_OVERHIT_DAMAGE = 100;
+	MAX_OVERHIT_DAMAGE = 100;
 	CURRENCY = "Gold";
 	VENDOR_RATIO = 0.25;
 	DEATH_PENALTY = true;
@@ -506,6 +514,18 @@ void loadMiscSettings() {
 				MIN_MISS_DAMAGE = popFirstInt(infile.val);
 				MAX_MISS_DAMAGE = popFirstInt(infile.val);
 				MAX_MISS_DAMAGE = std::max(MAX_MISS_DAMAGE, MIN_MISS_DAMAGE);
+			}
+			// @ATTR crit_damage_percent|int, int : Minimum, Maximum|The percentage of damage dealt when a critical hit occurs.
+			else if (infile.key == "crit_damage_percent") {
+				MIN_CRIT_DAMAGE = popFirstInt(infile.val);
+				MAX_CRIT_DAMAGE = popFirstInt(infile.val);
+				MAX_CRIT_DAMAGE = std::max(MAX_CRIT_DAMAGE, MIN_CRIT_DAMAGE);
+			}
+			// @ATTR overhit_damage_percent|int, int : Minimum, Maximum|The percentage of damage dealt when an overhit occurs.
+			else if (infile.key == "overhit_damage_percent") {
+				MIN_OVERHIT_DAMAGE = popFirstInt(infile.val);
+				MAX_OVERHIT_DAMAGE = popFirstInt(infile.val);
+				MAX_OVERHIT_DAMAGE = std::max(MAX_OVERHIT_DAMAGE, MIN_OVERHIT_DAMAGE);
 			}
 
 			else infile.error("Settings: '%s' is not a valid key.", infile.key.c_str());

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -183,6 +183,10 @@ extern int MIN_BLOCK;
 extern int MIN_AVOIDANCE;
 extern int MIN_MISS_DAMAGE;
 extern int MAX_MISS_DAMAGE;
+extern int MIN_CRIT_DAMAGE;
+extern int MAX_CRIT_DAMAGE;
+extern int MIN_OVERHIT_DAMAGE;
+extern int MAX_OVERHIT_DAMAGE;
 
 // Elemental types
 extern std::vector<Element> ELEMENTS;


### PR DESCRIPTION
Overhits are a new feature where excessive accuracy can produce an
alternate form of critical hit. As an example, let's say our hero has
150% accuracy and our target has 40% avoidance. This gives a "true"
accuracy value of 110%. To get our chance of scoring an overhit, we
subtract 100 from that value, meaning there is a 10% to score an overhit
in this case.